### PR TITLE
add optimist to package dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "license": "BSD-2-Clause",
   "dependencies": {
     "gaze": "~0.4.3",
-    "lodash.debounce": "~2.4.1"
+    "lodash.debounce": "~2.4.1",
+    "optimist": "~0.6.0"
   },
   "devDependencies": {
     "chai": "~1.8.1",


### PR DESCRIPTION
It seems this should include optimist as a dependency, since the script uses it.
