### PR TITLE
Guard the call to exec, prevents parallel execution

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,14 +3,27 @@ var gaze = require('gaze');
 var debounce = require('lodash.debounce');
 
 module.exports = function(pattern, cmd){
-  function runner(event, filepath){
+  var running = false
+  var runAgain = false
+
+  function runner() {
+    if (running) {
+      runAgain = true
+      return
+    }
     console.log('Running: '+ cmd);
+    running = true
     exec(cmd, function(err, stdout, stderr){
+      running = false
       if (err) {
         console.log(err);
       }
       console.log(stdout);
       console.log(stderr);
+      if (runAgain) {
+        runAgain = false
+        runner()
+      }
     });
   }
 


### PR DESCRIPTION
Having the same command execute multiple times in parallel is almost never what
I want, since it often leads to race conditions and/or resource conflicts.

If this doesn't jive with your usual use case, I could put in a command line flag that toggles this behaviour.
