### PR TITLE
fix missing color output and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,42 @@ $ npm install -g gazer
 ## Usage
 
 ```shell
-$ gazer --pattern "readme.md" echo "blorp"
+$ gazer --pattern 'README.md' echo 'blorp'
 
-[readme.md changes]
+[README.md changes]
 
-> "blorp"
+> 'blorp'
+```
+
+### Double dash
+
+If you need to pass an option (e.g. `-e`) to the command you're running, use
+`--` to separate the option arguments from the positional arguments:
+
+```shell
+$ gazer -p README.md -- node -e 'console.log("blorp");'
+```
+
+This feature is provided [for free](http://c2.com/cgi/wiki?ForFree)
+by [yargs](https://github.com/chevex/yargs).
+
+
+### Multiple patterns
+
+[gaze](https://github.com/shama/gaze#usage) accepts an array of patterns, so do `gazer`.
+
+```javascript
+gaze(['**/*.js', '!node_modules/**/*'], function() {
+  console.log('blorp');
+});
+```
+
+```shell
+$ gazer --pattern '**/*.js' --pattern '!node_modules/**/*' -- echo 'blorp'
+
+[index.js changes]
+
+> 'blorp'
 ```
 
 ### Arbitrary watch tasks with npm run
@@ -60,16 +91,4 @@ And then start the watcher:
 ```shell
 $ npm run watch-less
 ```
-
-### Double dash
-
-If you need to pass a -p argument to the command you're running, use
-`--` to separate the option arguments from the positional arguments:
-
-```shell
-$ gazer -p readme.md -- echo -p
-```
-
-This feature is provided [for free](http://c2.com/cgi/wiki?ForFree)
-by [optimist](https://github.com/substack/node-optimist).
 

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 var gazer = require('../');
 
-var argv = require('optimist')
+var argv = require('yargs')
   .usage('Usage: gazer -p "**/*.js" <your command>')
   .demand('p')
   .alias('p', 'pattern')

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -2,18 +2,11 @@
 var gazer = require('../');
 
 var argv = require('yargs')
-  .usage('Usage: gazer -p "**/*.js" <your command>')
+  .usage('Usage: gazer -p "**/*.js" -- <your command>')
   .demand('p')
+  .demand(1, 'You must provide a command to run')
   .alias('p', 'pattern')
   .describe('p', 'Files to watch, globbing supported')
   .argv;
 
-var pattern = argv.pattern;
-var patternIndex = process.argv.indexOf(pattern) + 1;
-var cmd = process.argv.slice(patternIndex, Infinity).join(' ');
-
-if (cmd.length === 0) {
-  throw new Error('You must provide a command to run');
-}
-
-gazer(pattern, cmd);
+gazer(argv.pattern, argv._[0], argv._.slice(1));

--- a/index.js
+++ b/index.js
@@ -2,10 +2,11 @@ var exec = require('child_process').exec;
 var gaze = require('gaze');
 var debounce = require('lodash.debounce');
 
-module.exports = function(pattern, cmd){
+module.exports = function(pattern, cmd, args){
   function runner(event, filepath){
-    console.log('Running: '+ cmd);
-    exec(cmd, function(err, stdout, stderr){
+    var command = cmd + ' ' + args.join(' ');
+    console.log('Running: '+ command);
+    exec(command, function(err, stdout, stderr){
       if (err) {
         console.log(err);
       }

--- a/index.js
+++ b/index.js
@@ -3,9 +3,16 @@ var gaze = require('gaze');
 var debounce = require('lodash.debounce');
 
 module.exports = function(pattern, cmd, args){
+  var opts = { stdio: 'inherit' };
+  if (process.platform === 'win32') {
+    args = ['/c', '"' + cmd + '"'].concat(args)
+    cmd = 'cmd'
+    opts.windowsVerbatimArguments = true
+  }
+
   function runner(event, filepath){
     console.log('Running: '+ cmd + ' ' + args.join(' '));
-    spawn(cmd, args, { stdio: 'inherit' });
+    spawn(cmd, args, opts);
   }
 
   gaze(pattern, function(err, watcher){

--- a/index.js
+++ b/index.js
@@ -1,18 +1,11 @@
-var exec = require('child_process').exec;
+var spawn = require('child_process').spawn;
 var gaze = require('gaze');
 var debounce = require('lodash.debounce');
 
 module.exports = function(pattern, cmd, args){
   function runner(event, filepath){
-    var command = cmd + ' ' + args.join(' ');
-    console.log('Running: '+ command);
-    exec(command, function(err, stdout, stderr){
-      if (err) {
-        console.log(err);
-      }
-      console.log(stdout);
-      console.log(stderr);
-    });
+    console.log('Running: '+ cmd + ' ' + args.join(' '));
+    spawn(cmd, args, { stdio: 'inherit' });
   }
 
   gaze(pattern, function(err, watcher){

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
   "dependencies": {
     "gaze": "~0.5.1",
     "lodash.debounce": "~3.0.1",
-    "yargs": "~3.0.4"
+    "yargs": "~3.4.5"
   },
   "devDependencies": {
-    "chai": "~2.0.0",
+    "chai": "~2.1.1",
     "less": "^2.4.0",
-    "mocha": "~2.1.0"
+    "mocha": "~2.2.1"
   },
   "directories": {
     "example": "example",

--- a/package.json
+++ b/package.json
@@ -12,14 +12,14 @@
   "author": "wookiehangover",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "gaze": "~0.4.3",
-    "lodash.debounce": "~2.4.1",
-    "optimist": "~0.6.0"
+    "gaze": "~0.5.1",
+    "lodash.debounce": "~3.0.1",
+    "yargs": "~3.0.4"
   },
   "devDependencies": {
-    "chai": "~1.8.1",
-    "mocha": "~1.16.2",
-    "less": "~1.6.0"
+    "chai": "~2.0.0",
+    "less": "^2.4.0",
+    "mocha": "~2.1.0"
   },
   "directories": {
     "example": "example",

--- a/test/index.js
+++ b/test/index.js
@@ -7,7 +7,7 @@ describe('gazer', function(){
   var compile = './node_modules/.bin/lessc --verbose example/foo.less example/foo.css';
 
   it('should watch files and run a command', function(done){
-    var cmd = ['./bin/cmd.js --pattern', pattern, compile];
+    var cmd = ['./bin/cmd.js --pattern', pattern, '--', compile];
     var child = exec(cmd.join(' '), function(err, stdout, stderr){
       if (err) {
         assert.ok(false, err);

--- a/test/index.js
+++ b/test/index.js
@@ -17,7 +17,6 @@ describe('gazer', function(){
 
     child.stdout.on('data', function(data){
       if (/Watching/.test(data)) {
-        console.log(data.trim(), 'Watching "example/foo.less" : 1 file');
         assert.equal(data.trim(), 'Watching "example/foo.less" : 1 file');
         process.nextTick(function(){
           exec('echo "* { color: black }" > example/foo.less');
@@ -31,4 +30,25 @@ describe('gazer', function(){
     });
   });
 
+  it('should handle mixed quotations of diffrent types correctly', function(done) {
+    var cmd = './bin/cmd.js -p example/foo.less -- node -e \'console.log("blorp");\'';
+    var child = exec(cmd, function(err, stdout, stderr){
+      if (err) {
+        assert.notOk(err, err);
+        done();
+      }
+    });
+
+    child.stdout.on('data', function(data){
+      if (/Watching/.test(data)) {
+        process.nextTick(function(){
+          exec('echo "* { color: black }" > example/foo.less');
+        });
+      }
+
+      if (/^blorp\n/.test(data)) {
+        done();
+      }
+    });
+  });
 });


### PR DESCRIPTION
First of all: Thanks a lot for this project :bowtie:
# Bugfixes

I have noticed that, gazer doesn't support commands with colored output:

``` shell
$ gazer -p index.js grep if index.js --color
# respectively:
$ gazer -p index.js -- grep if index.js --color
```

Additionally gazer is unable to handle different types of quotes:

``` shell
$ gazer -p README.md node -e 'console.log("blorp");'
Watching "README.md" : 1 file
Running: node -e console.log("blorp");
{ [Error: Command failed: /bin/sh -c node -e console.log("blorp");
/bin/sh: 1: Syntax error: "(" unexpected
…
```

This PR fixes both issues by switching from [child_process.exec](http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback) to [child_process.spawn](http://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options).
# Drawbacks

The only drawback of this PR is, that **maybe** it isn't fully backward-compatible. The following will execute `grep if index.js` (without the `--color` option):

``` shell
$ gazer -p index.js grep if index.js --color
```

But the following works like expected:

``` shell
$ gazer -p index.js -- grep if index.js --color
```

That's because `--` and `-p` handling was somewhat inconsistent, so I've simplified it. Even more it doesn't worked - at least on Linux:

``` shell
$ gazer -p index.js -- echo -p
Watching "index.js" : 1 file
Running: -- echo -p
{ [Error: Command failed: /bin/sh -c -- echo -p
/bin/sh: 0: Illegal option --
…

$ gazer -p index.js echo -- -p
Watching "index.js" : 1 file
Running: echo -- -p
-- -p
…
```

Im my opinion it is overly complex to handle all `--` and `-p` cases. And requiring `--` for the user command options is at least usual in Linux environments…
